### PR TITLE
feat: Add github actions to publish package

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,0 +1,100 @@
+name: Tag repo; build and publish assets
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag-new-version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.new_tag }}
+      version: ${{ steps.tag.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v4.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          release_branches: main
+
+  build-and-publish-package:
+    runs-on: ubuntu-latest
+
+    name: Build and publish PyPI package
+    needs: tag-new-version
+    if: needs.tag-new-version.outputs.tag
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install wheel package
+      run: |
+        pip install wheel
+
+    - name: Generate correct value for VERSION file
+      run: |
+        echo ${{ needs.tag-new-version.outputs.tag }} > opensafely/VERSION
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@master
+      if: needs.tag-new-version.outputs.tag
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
+
+    # As well as uploading to PyPI it's useful to publish them as Github
+    # Release Assets for use in contexts where we have access to Github but not
+    # to PyPI
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ needs.tag-new-version.outputs.tag }}
+        release_name: ${{ needs.tag-new-version.outputs.tag }}
+        draft: false
+        prerelease: false
+
+    - name: Get release filenames
+      id: get_release_filenames
+      run: |
+        cd dist
+        whl_filename=$(ls *.whl | head -n 1)
+        sdist_filename=$(ls *.tar.gz | head -n 1)
+        echo "::set-output name=whl_filename::$whl_filename"
+        echo "::set-output name=sdist_filename::$sdist_filename"
+
+    - name: "Upload release asset: wheel"
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ steps.get_release_filenames.outputs.whl_filename }}
+        asset_name: ${{ steps.get_release_filenames.outputs.whl_filename }}
+        asset_content_type: application/zip
+
+    - name: "Upload release asset: sdist"
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/${{ steps.get_release_filenames.outputs.sdist_filename }}
+        asset_name: ${{ steps.get_release_filenames.outputs.sdist_filename }}
+        asset_content_type: application/gzip

--- a/osgithub/VERSION
+++ b/osgithub/VERSION
@@ -1,1 +1,1 @@
-0.1
+not-from-a-package


### PR DESCRIPTION
This is entirely a copy of the workflow in opensafely-cli:
https://github.com/opensafely-core/opensafely-cli/blob/main/.github/workflows/build_and_publish.yaml

