### PR TITLE
feat: switch get_last_updated from date -> datetime

### DIFF
--- a/osgithub/github.py
+++ b/osgithub/github.py
@@ -364,18 +364,18 @@ class GithubRepo:
 
     def get_last_updated(self, path, ref):
         """
-        Finds the date of the last commit for a file
+        Finds the datetime of the last commit for a file
 
         Args:
             path (str): path to the file in the repo
             ref (str): branch/tag/sha
 
         Returns:
-            str: HTML from readme (at ROOT)
+            datetime: a datetime instance of the last commit's committed date
         """
         commits = self.get_commits_for_file(path, ref, number_of_commits=1)
         last_commit_date = commits[0]["commit"]["committer"]["date"]
-        return datetime.strptime(last_commit_date, "%Y-%m-%dT%H:%M:%SZ").date()
+        return datetime.strptime(last_commit_date, "%Y-%m-%dT%H:%M:%SZ")
 
     def get_readme(self, tag="main"):
         """

--- a/osgithub/github.py
+++ b/osgithub/github.py
@@ -12,7 +12,7 @@ Optionally uses requests caching to avoid repeated calls to the API.
 """
 import json
 from base64 import b64decode
-from datetime import datetime
+from datetime import datetime, timezone
 from os import environ
 from pathlib import Path
 
@@ -375,7 +375,11 @@ class GithubRepo:
         """
         commits = self.get_commits_for_file(path, ref, number_of_commits=1)
         last_commit_date = commits[0]["commit"]["committer"]["date"]
-        return datetime.strptime(last_commit_date, "%Y-%m-%dT%H:%M:%SZ")
+        dt = datetime.strptime(last_commit_date, "%Y-%m-%dT%H:%M:%SZ")
+        # we know GitHub is giving us a UTC timezone because the string ends in
+        # Z, but Python's strptime can't consume that with it's %Z operator so
+        # we're matching it literally and then setting the timezone to UTC.
+        return dt.replace(tzinfo=timezone.utc)
 
     def get_readme(self, tag="main"):
         """

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64encode
-from datetime import date
+from datetime import datetime
 from os import environ
 
 import pytest
@@ -285,7 +285,7 @@ def test_github_repo_get_last_updated(httpretty):
     )
 
     last_updated = repo.get_last_updated(path="test-folder/test-file.html", ref="main")
-    assert last_updated == date(2021, 3, 1)
+    assert last_updated == datetime(2021, 3, 1, 10, 0, 0)
 
 
 @pytest.mark.parametrize(
@@ -546,7 +546,7 @@ def test_github_repo_get_contents_too_large_file(httpretty):
 
     content_file = repo.get_contents("test-folder/test-file.html", ref="main")
     assert content_file.decoded_content == str_content
-    assert content_file.last_updated == date(2021, 3, 1)
+    assert content_file.last_updated == datetime(2021, 3, 1, 10, 0, 0)
 
 
 def test_github_repo_get_readme(httpretty):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,6 @@
 import json
 from base64 import b64encode
-from datetime import datetime
+from datetime import datetime, timezone
 from os import environ
 
 import pytest
@@ -285,7 +285,7 @@ def test_github_repo_get_last_updated(httpretty):
     )
 
     last_updated = repo.get_last_updated(path="test-folder/test-file.html", ref="main")
-    assert last_updated == datetime(2021, 3, 1, 10, 0, 0)
+    assert last_updated == datetime(2021, 3, 1, 10, 0, 0, tzinfo=timezone.utc)
 
 
 @pytest.mark.parametrize(
@@ -546,7 +546,9 @@ def test_github_repo_get_contents_too_large_file(httpretty):
 
     content_file = repo.get_contents("test-folder/test-file.html", ref="main")
     assert content_file.decoded_content == str_content
-    assert content_file.last_updated == datetime(2021, 3, 1, 10, 0, 0)
+    assert content_file.last_updated == datetime(
+        2021, 3, 1, 10, 0, 0, tzinfo=timezone.utc
+    )
 
 
 def test_github_repo_get_readme(httpretty):


### PR DESCRIPTION
This changes `get_last_updated()` to return a timezone-aware `datetime` object.  Users of the library can still discard this extra information if they want.