### PR TITLE
fix: handle Contents API not returning an error

### DIFF
--- a/osgithub/__init__.py
+++ b/osgithub/__init__.py
@@ -1,14 +1,7 @@
-from .github import (
-    GithubAPIException,
-    GithubAPIFileTooLarge,
-    GithubClient,
-    GithubContentFile,
-    GithubRepo,
-)
+from .github import GithubAPIException, GithubClient, GithubContentFile, GithubRepo
 
 
 __all__ = [
-    "GithubAPIFileTooLarge",
     "GithubAPIException",
     "GithubClient",
     "GithubContentFile",

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -498,9 +498,16 @@ def test_github_repo_get_contents_too_large_file(httpretty):
     register_uri(
         httpretty,
         "repos/test/foo/contents/test-folder/test-file.html",
-        status=403,
+        status=200,
         queryparams=dict(ref="main"),
-        body={"errors": [{"code": "too_large", "message": "File was too large"}]},
+        body={
+            "name": "test-file.html",
+            "path": "test-folder/test-file.html",
+            "sha": "abcd1234",
+            "size": 1234,
+            "encoding": "base64",
+            "content": "",
+        },
     )
 
     # gets the parent folder contents


### PR DESCRIPTION
This removes the `GithubAPIFileTooLarge` exception because the Contents API doesn't return an error when a file is too large to return its content.  The response's `content` value is empty and we still get a 200 with all the other metadata.

We can probably further improve this as per #55 but I didn't want to dig too deep while we had a broken report.

Ref: opensafely-core/output-explorer#321