### PR TITLE
feat: Add ability to get contributors to repo

### DIFF
--- a/osgithub/github.py
+++ b/osgithub/github.py
@@ -434,6 +434,18 @@ class GithubRepo:
             "date": content["committer"]["date"],
         }
 
+    def get_contributors(self):
+        """
+        Gets contributors to the repo
+
+        Returns:
+            List of strings, each representing a contributor's login
+        """
+        path_segments = [*self.repo_path_segments, "contributors"]
+        content = self.client.get_json(path_segments)
+        contrib_list = [contrib["login"] for contrib in content]
+        return contrib_list
+
     def clear_cache(self):
         """Clears all request cache urls for this repo"""
         cached_urls = self.client.session.cache.urls()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -630,6 +630,13 @@ def test_github_repo_get_commit(httpretty):
     }
 
 
+def test_github_repo_get_contributors(httpretty):
+    contribs = [{"login": "octocat"}, {"login": "octodog"}]
+    register_uri(httpretty, "repos/test/foo/contributors", status=200, body=contribs)
+    repo = GithubRepo(client=GithubClient(use_cache=False), owner="test", name="foo")
+    assert repo.get_contributors() == ["octocat", "octodog"]
+
+
 def test_clear_cache(httpretty, reset_environment_after_test):
     # mock the requests
     register_uri(httpretty, "repos/test/foo", body={"name": "foo", "description": ""})


### PR DESCRIPTION
This adds `GithubRepo.get_contributors`, which gets the contributors to the repo represented by the `GithubRepo` instance. A contributor is represented by their login (username), as their name isn't provided by the endpoint. Contributors are listed by number of commits, in descending order.

Contributors are required by opensafely-core/actions-registry#420.