### PR TITLE
feat: Add `GithubRepo.get_topics` method

### DIFF
--- a/osgithub/github.py
+++ b/osgithub/github.py
@@ -446,6 +446,20 @@ class GithubRepo:
         contrib_list = [contrib["login"] for contrib in content]
         return contrib_list
 
+    def get_topics(self):
+        """
+        Gets the repo's topics.
+
+        If the repo's name and about are also being fetched from GitHub,
+        consider setting `use_cache` to True in the GithubClient to avoid
+        duplicate calls to the repo endpoint.
+
+        Returns:
+            list[str]: list of topics
+        """
+        content = self.client.get_json(self.repo_path_segments)
+        return content["topics"]
+
     def clear_cache(self):
         """Clears all request cache urls for this repo"""
         cached_urls = self.client.session.cache.urls()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -637,6 +637,25 @@ def test_github_repo_get_contributors(httpretty):
     assert repo.get_contributors() == ["octocat", "octodog"]
 
 
+@pytest.mark.parametrize(
+    "use_cache,num_requests",
+    [
+        (True, 1),
+        (False, 2),
+    ],
+)
+def test_github_repo_get_topics(httpretty, use_cache, num_requests):
+    register_uri(
+        httpretty,
+        "repos/test/foo",
+        status=200,
+        body={"name": "foo", "description": "a description", "topics": ["bar", "baz"]},
+    )
+    repo = GithubClient(use_cache=use_cache).get_repo("test", "foo")
+    assert repo.get_topics() == ["bar", "baz"]
+    assert len(httpretty.latest_requests()) == num_requests
+
+
 def test_clear_cache(httpretty, reset_environment_after_test):
     # mock the requests
     register_uri(httpretty, "repos/test/foo", body={"name": "foo", "description": ""})


### PR DESCRIPTION
- `get_topics` calls the repo endpoint to get the repo's topics. The repo endpoint might have been called previously to retrieve the repo's name and description, so it is possible that by calling `get_topics` we would be calling the endpoint twice. This can be avoided by setting `use_cache=True` when instantiating the `GithubClient` for use.

- An alternative implementation would be to always retrieve topics along with the repo's name and description, but this would require modifying the API of the `GithubRepo` class and its `get_repo_details` method. Changing the API seems like a large drawback, especially since topics are not always needed.
Calling the endpoint a second time only when topics are needed and the GithubClient is not using the cache seems like a reasonable trade-off.

- Topics are required by opensafely-core/actions-registry#433.